### PR TITLE
Lua 5.2+ support

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,27 @@
+# License
+
+* Author  : Brian Maher <brian at brimworks dot com>
+* Library : lua_yajl - Lua 5.1 interface to yajl.
+
+## The MIT License
+
+Copyright (c) 2009-2024 Brian Maher
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/lua_yajl.c
+++ b/lua_yajl.c
@@ -12,6 +12,12 @@
 
 static void* js_null;
 
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM >= 502
+#define lua_objlen(x, y) lua_rawlen(x, y)
+#define lua_setfenv(x, y) lua_setuservalue(x, y)
+#define lua_getfenv(x, y) lua_getuservalue(x, y)
+#endif
+
 static int js_generator(lua_State *L);
 static int js_generator_value(lua_State *L);
 static void js_parser_assert(lua_State* L,
@@ -886,7 +892,7 @@ static int js_generator(lua_State *L) {
     /* {args}, ?, tbl */
     lua_newtable(L);
 
-    /* Validate and save in fenv so it isn't gc'ed: */
+    /* Validate and save in registry so it isn't gc'ed: */
     lua_getfield(L, 1, "printer");
     if ( ! lua_isnil(L, -1) ) {
         js_printer_ctx* print_ctx;

--- a/lua_yajl.c
+++ b/lua_yajl.c
@@ -1,3 +1,24 @@
+/**
+ * Copyright (c) 2009-2024 Brian Maher
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 #include <yajl/yajl_parse.h>
 #include <yajl/yajl_gen.h>
 #include <lua.h>

--- a/tap.lua
+++ b/tap.lua
@@ -1,8 +1,8 @@
-module(..., package.seeall)
-
+-- module(..., package.seeall)
+local tap = {}
 local counter = 1
 
-function ok(assert_true, desc)
+function tap.ok(assert_true, desc)
    local msg = ( assert_true and "ok " or "not ok " ) .. counter
    if ( desc ) then
       msg = msg .. " - " .. desc
@@ -10,3 +10,5 @@ function ok(assert_true, desc)
    print(msg)
    counter = counter + 1
 end
+
+return tap

--- a/tap.lua
+++ b/tap.lua
@@ -1,4 +1,3 @@
--- module(..., package.seeall)
 local tap = {}
 local counter = 1
 

--- a/test.lua
+++ b/test.lua
@@ -1,9 +1,5 @@
 print "1..5"
 
-local src_dir, build_dir = ...
-package.path  = src_dir .. "?.lua;" .. package.path
-package.cpath = build_dir .. "?.so;" .. package.cpath
-
 local tap   = require("tap")
 local yajl  = require("yajl")
 local ok    = tap.ok

--- a/test.lua
+++ b/test.lua
@@ -90,7 +90,7 @@ function test_generator()
                       "obool_key", { [true] = true },
                       "onull_key", { [yajl.null] = yajl.null },
                    })
-   generator:integer(10.3)
+   generator:integer(10)
    generator:double(10.3)
    generator:number(10.3)
    generator:string("a string")
@@ -109,7 +109,7 @@ end
 function test_simple()
     -- Thanks to fab13n@github for this bug report:
     -- https://github.com/brimworks/lua-yajl/issues/8
-    assert(yajl.to_value(yajl.to_string(0) == 0))
+    assert(yajl.to_value(yajl.to_string(0)) == 0)
 
    local expect =
       '['..


### PR DESCRIPTION
Validated by:

```bash
brew install luaver
brew install yajl
# Install two versions of lua and luarocks, be sure to say "yes" when appropriate
luaver install 5.1.5
luaver install-luarocks 3.11.1
luaver install 5.4.7
# Run this command in the checked out repository, assuming yajl was installed in /opt/homebrew
luarocks test rockspecs/lua-yajl-2.0-1.rockspec  YAJL_DIR=/opt/homebrew
# Switch to the 5.1 version, and run the same test command:
luaver use 5.1.5
luarocks test rockspecs/lua-yajl-2.0-1.rockspec  YAJL_DIR=/opt/homebrew
```